### PR TITLE
Handle spurious "demand":1 when "demandBracket":0 in Companion output

### DIFF
--- a/edce/eddn.py
+++ b/edce/eddn.py
@@ -118,10 +118,10 @@ def postMarketData(data):
                 tmpCommodity["name"]        = convertCommodityEDDN(commodity.name.strip()).strip()
                 
                 tmpCommodity["buyPrice"]    = math.floor(commodity.buyPrice)
-                tmpCommodity["supply"]      = math.floor(commodity.stock)
+                tmpCommodity["supply"]      = commodity.stockBracket and math.floor(commodity.stock)
                 
                 tmpCommodity["sellPrice"]   = math.floor(commodity.sellPrice)
-                tmpCommodity["demand"]      = math.floor(commodity.demand)
+                tmpCommodity["demand"]      = commodity.demandBracket and math.floor(commodity.demand)
                 
                 if commodity.stockBracket > 0:
                     tmpCommodity['supplyLevel'] = getBracket(commodity.stockBracket)


### PR DESCRIPTION
Post 1.3, when demandBracket=0 the Companion API output sets demand=1, even though there is no demand. See e.g. http://ross.eddb.io/eddn/log/5246771
