### PR TITLE
Stop using test schema now v2 is the only supported commodities schema.

### DIFF
--- a/edce/eddn.py
+++ b/edce/eddn.py
@@ -14,7 +14,7 @@ import edce.config
 import edce.globals
 import edce.error
 
-testSchema = True
+testSchema = False
 
 def convertCategoryEDDN(name):
     commoditiesCategory                 = {}


### PR DESCRIPTION
EDDN now only supports the v2 commodities schema, which is no longer in draft, so submit against it by default.
