### PR TITLE
client: only post market data to EDDN if ship is docked

### DIFF
--- a/edce_client.py
+++ b/edce_client.py
@@ -33,9 +33,10 @@ try:
 		print("Ship:\t" + data.ship.name)
 	
 	if edce.config.getString('preferences','enable_eddn').lower().find('y') >= 0:
-		print("Attempting to post market data to EDDN, this may take a minute...")
-		edce.eddn.postMarketData(data)
-		print("Done.")
+		if data.commander.docked:
+			print("Attempting to post market data to EDDN, this may take a minute...")
+			edce.eddn.postMarketData(data)
+			print("Done.")
 	
 except edce.error.Error as e:
 	print("EDCE: " + e.message)


### PR DESCRIPTION
I noticed `EDCE: Error: EDDN postMarketData FAIL pilot must be docked` in the client output, so I modified the client to only send the market data if the pilot is docked.
