### PR TITLE
Updated search for players ships to pass indices to data.ships so it can be retrieved

### DIFF
--- a/player_dump.py
+++ b/player_dump.py
@@ -42,13 +42,13 @@ if "ships" in data:
 	
 	all_ships = {}
 	for ship in data.ships:
-		starsystem = data.ships[ship].starsystem
-		starsystem_station = data.ships[ship].station
+		starsystem = data.ships[data.ships.index(ship)].starsystem
+		starsystem_station = data.ships[data.ships.index(ship)].station
 		if starsystem and starsystem_station:
 		        station = starsystem.name + "/" + starsystem_station.name
 		        if not station in all_ships:
 			        all_ships[station]=[]
-		        all_ships[station].append(data.ships[ship].name)
+		        all_ships[station].append(data.ships[data.ships.index(ship)].name)
 
 	for s in OrderedDict(sorted(all_ships.items())):
 		print(alignStr(s,", ".join(all_ships[s])))


### PR DESCRIPTION
Example error:

Traceback (most recent call last):
File "./player_dump.py", line 45, in <module>
starsystem = data.ships[ship].starsystem
TypeError: list indices must be integers or slices, not edict

Changed to:
starsystem = data.ships[data.ships.index(ship)].starsystem

This returns the indices correctly where the ship exists in the
dictionary.

Replaced as appropriate in code. Tested against Python 3.5
